### PR TITLE
Added ionLeave output event to be emitted on leave for ion-range

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -307,6 +307,10 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
    */
   @Output() ionChange: EventEmitter<Range> = new EventEmitter<Range>();
 
+  /**
+   * @output {Range} Emitted when the range selector is being left (pointer up).
+   */
+  @Output() ionLeave: EventEmitter<Range> = new EventEmitter<Range>();
 
   constructor(
     private _form: Form,
@@ -411,6 +415,9 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
 
       // trigger a haptic end
       this._haptic.gestureSelectionEnd();
+	  
+      // trigger ionLeave event
+      this.ionLeave.emit(this);
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, there is no way to know if `ionic-range` is being focused or not.

#### Changes proposed in this pull request:

- Add an output event called `ionLeave` to `ion-range`, that is being triggered when the range is being left (pointer up)
- `<ion-range (ionLeave)="onLeave($event)"></ion-range>`

**Ionic Version**: 2.2.0

**Fixes**: This feature request: https://github.com/driftyco/ionic/issues/10760

**Notes**:
- Missing documentation - please let me know if this PR is in the right direction, and I'll also add doc